### PR TITLE
Fix duplicated GitHub action runs

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -5,7 +5,6 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
-  pull_request_target:
 
 jobs:
   test:


### PR DESCRIPTION
It is not recommended to use `pull_request_target` when code is executed
that could modify the repository.