### PR TITLE
Run Pronto in a GitHub action separate from the pull request

### DIFF
--- a/.github/workflows/pronto.yml
+++ b/.github/workflows/pronto.yml
@@ -1,0 +1,38 @@
+name: Pronto
+
+on:
+  pull_request_target:
+
+jobs:
+  pronto:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.5
+          bundler-cache: true
+      - name: Cache gems
+        id: cache-gems
+        uses: actions/cache@v2
+        with:
+          path: gem_cache
+          key: ${{ runner.os }}-gems
+      - name: Install pronto
+        env:
+          GEM_HOME: gem_cache
+          GEM_PATH: gem_cache
+        run: gem install pronto
+      - name: Run pronto
+        env:
+          GEM_HOME: gem_cache
+          GEM_PATH: gem_cache
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          export PATH=$(pwd)/gem_cache/bin:$PATH
+          hub pr checkout ${{ github.event.pull_request.id }}
+          git fetch origin ${{ github.event.pull_request.base.ref }}
+          PRONTO_PULL_REQUEST_ID=$(cat PULL_REQUEST_NUMBER) \
+          PRONTO_GITHUB_ACCESS_TOKEN="${{ github.token }}" \
+            pronto run -f github_status github_pr -c origin/${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -35,9 +35,13 @@ jobs:
         with:
           coverageCommand: bundle exec rspec
       - if: matrix.ruby-version == '2.4' && github.event_name == 'pull_request'
-        name: Run pronto
+        name: Save pull request information
         run: |
-          git fetch -q origin ${{ github.context.pull_request.base.sha }}
-          PRONTO_PULL_REQUEST_ID=${{github.event.number}} \
-          PRONTO_GITHUB_ACCESS_TOKEN="${{ github.token }}" \
-            bundle exec pronto run -f github_status github_pr -c origin/${{ github.event.pull_request.base.ref }}
+          mkdir -p ./test_artifacts
+          echo ${{ github.event.number }} > ./test_artifacts/PULL_REQUEST_NUMBER
+          echo ${{ github.event.pull_request.base.ref }} > ./test_artifacts/PULL_REQUEST_TARGET_BRANCH
+      - if: matrix.ruby-version == '2.4' && github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v2
+        with:
+          name: test_artifacts
+          path: test_artifacts/


### PR DESCRIPTION
When the specs action is triggered by `pull_request` Pronto can not
post reports to GitHub because there isn't a token present (the action
only has read access to the repository).

Since the `pull_request_target` action has write access to the repository
we must make sure that no code that is coming from the PR is executed.
The workflow definition used for those actions are always taken from the
target branch which means the pull request can not modify what is run.